### PR TITLE
corrections to named-pipes.md

### DIFF
--- a/named-pipes.md
+++ b/named-pipes.md
@@ -130,5 +130,5 @@ Example excluding known good Pipe Names
 ```
 
 One thing to consider is that Sysmon uses a minifilter just like the
-file events, any AV or EDR with a higher altitude number if it triggers
-on the named pipe and block Sysmon will not log the event.
+file events. If any AV or EDR with a lower altitude number triggers
+on a named pipe and blocks it, Sysmon will not log the event.


### PR DESCRIPTION
Line 132-134. Cleaned up grammar. Altered description on line 134: the line states that AV/EDRs with higher altitude numbers could block a pipe causing Sysmon not to log an event. AV altitude range is lower in terms of number values and described as lower elsewhere in the document.