### PR TITLE
Correct Sysmon event-type documentation (Events 27-29) and fix eBPF link

### DIFF
--- a/chapters/file-blockshredding.md
+++ b/chapters/file-blockshredding.md
@@ -1,7 +1,7 @@
 File Block EXE
 ===========
 
-On version 14.1 of Sysmon the capability to log and block when a process is deleting a file by overwriting its file blocks. Events will be loggedusing **EventID 27**. This event type is found under schema version 4.83.
+On version 14.1 of Sysmon the capability to log and block when a process is deleting a file by overwriting its file blocks. Events will be logged using **EventID 28**. This event type is found under schema version 4.83.
 
 
 ![minifilter](./media/image36.png)

--- a/chapters/what-is-sysmon.md
+++ b/chapters/what-is-sysmon.md
@@ -1,13 +1,13 @@
 # What is Sysmon
 
-Sysmon (System Monitor) is a free, advanced system monitoring tool developed by Mark Russinovich and Tomas Garnier, with contributions from David Magnotti, Mark Cook, Rob Mead, Giulia Biagini, Alex Mihaiuc, Kevin Sheldrake, and John Lambert.  
+Sysmon (System Monitor) is a free, advanced system monitoring tool developed by Mark Russinovich and Thomas Garnier, with contributions from David Magnotti, Mark Cook, Rob Mead, Giulia Biagini, Alex Mihaiuc, Kevin Sheldrake, and John Lambert.  
 Originally, Sysmon was created for internal use at Microsoft, but it is now widely used by security professionals to enhance visibility into system activity and detect abnormal behavior or potential threats.
 
 Sysmon enables defenders to better detect suspicious activity by monitoring and logging a broad range of system events, such as process creation, network connections, and changes to files or registry keys. These logs are especially valuable for security investigations and threat detection.
 
 ## Sysmon on Windows
 
-Sysmon for Windows supports ARM, x64 and x86 systems. Installation and configuration are managed through a single command-line tool. When installed, Sysmon logs events to the Microsoft-Windows-Sysmon/Operational Event Log.
+Sysmon for Windows supports ARM, x64 and x86 systems. The download provides three binaries for these architectures: Sysmon.exe (32-bit x86), Sysmon64.exe (64-bit x64), and Sysmon64a.exe (64-bit ARM64). Installation and configuration are managed through a single command-line tool. When installed, Sysmon logs events to the Microsoft-Windows-Sysmon/Operational Event Log.
 
 ### Windows Supported Event Types
 
@@ -42,7 +42,14 @@ The following table lists the event types and corresponding event IDs generated 
 | Clipboard Capture                  | 24       |
 | Process Tampering                  | 25       |
 | File Delete Detected               | 26       |
+| File Block Executable              | 27       |
+| File Block Shredding               | 28       |
+| File Executable Detected           | 29       |
 | Error                              | 255      |
+
+### Windows on ARM (ARM64)
+
+Sysmon runs natively on Windows on ARM (ARM64 / AArch64) devices — such as Snapdragon-based PCs, the Surface Pro X, and ARM64 virtual machines — through the dedicated `Sysmon64a.exe` build. Event coverage on ARM64 is identical to x64: the same event IDs and configuration schema apply, since the processor architecture does not change which events Sysmon produces. Because `SysmonDrv` is a kernel-mode driver that must match the operating system architecture, the native `Sysmon64a.exe` is required on ARM64 — the x64 build's driver cannot be loaded under the system's x86/x64 emulation.
 
 ## Sysmon on Linux
 
@@ -79,7 +86,7 @@ Sysmon for Linux uses the sysinternalsEBPF library to capture file and network a
 
 Both sysinternalsEBPF and Sysmon for Linux are open source projects, allowing the community to contribute and extend their features. You can find the projects and source code on GitHub:  
 - [Sysmon for Linux](https://github.com/Sysinternals/SysmonForLinux)  
-- [sysinternalsEBPF library](https://github.com/Sysinternals/ebpf-for-windows)
+- [sysinternalsEBPF library](https://github.com/Sysinternals/SysinternalsEBPF)
 
 ## Further Resources
 


### PR DESCRIPTION
Several accuracy fixes to the Sysmon event documentation. The "Windows Supported Event Types"
table stopped at Event 26 even though the guide already has dedicated chapters for File Block
Executable, File Block Shredding and File Executable Detected. The File Block Shredding chapter
also listed the wrong event ID, and the `What is Sysmon` chapter linked to the wrong GitHub repo
for the sysinternalsEBPF library (the guide's own eBPF chapter has the correct one).

### Changes
- `chapters/what-is-sysmon.md`
  - Added the missing event rows: **File Block Executable (27)**, **File Block Shredding (28)**, **File Executable Detected (29)**.
  - Fixed the broken reference: sysinternalsEBPF library now points to `https://github.com/Sysinternals/SysinternalsEBPF` (was the unrelated `ebpf-for-windows` repo; confirmed against `chapters/eBPF.md`).
  - Noted that the Windows download provides three binaries (x86 / x64 / ARM64).
  - **Added a dedicated "Windows on ARM (ARM64)" subsection**: native ARM64 support via `Sysmon64a.exe`, event coverage identical to x64 (same IDs/schema), and that the native build is required because `SysmonDrv` must match the OS architecture.
  - Fixed author-name typo: "Tomas Garnier" → "Thomas Garnier".
- `chapters/file-blockshredding.md`
  - Corrected the event ID: File Block Shredding is **EventID 28**, not 27 (27 is File Block Executable). Also fixed the "loggedusing" → "logged using" typo.